### PR TITLE
Identify migrations by filename instead of id

### DIFF
--- a/src/pg/migrations.clj
+++ b/src/pg/migrations.clj
@@ -39,10 +39,11 @@
       )))
 
 (defn process-migration-entry [entry entry-name]
-  (merge
-   (parse-migration (slurp entry))
-   {:id (second (str/split (str/replace entry-name #"\.sql$" "") #"_" 2))
-    :file (str/replace entry-name #"\.sql$" "")}))
+  (let [file (str/replace entry-name #"\.sql$" "")]
+    (merge
+     (parse-migration (slurp entry))
+     {:id file
+      :file file})))
 
 (defn is-sql-migration? [entry]
   (and (not (.isDirectory entry))

--- a/test/pg_test.clj
+++ b/test/pg_test.clj
@@ -43,7 +43,7 @@
 
   (pg/migrate-prepare context)
 
-  (pg/migrate-up context "init")
+  (pg/migrate-up context "20250216211605_init")
 
   (matcho/match
       (pg.repo/get-table-definition context "patient")
@@ -58,15 +58,15 @@
 
   (matcho/match
       (pg/execute! context {:sql "select * from _migrations"})
-    [{:id "init", :file "20250216211605_init",}])
+    [{:id "20250216211605_init", :file "20250216211605_init",}])
 
-  (pg/migrate-up context "add_pt_index")
+  (pg/migrate-up context "20250216213534_add_pt_index")
   (matcho/match
       (pg/execute! context {:sql "select * from _migrations"})
-    [{:id "init", :file "20250216211605_init",}
-     {:id "add_pt_index", :file "20250216213534_add_pt_index",}])
+    [{:id "20250216211605_init", :file "20250216211605_init",}
+     {:id "20250216213534_add_pt_index", :file "20250216213534_add_pt_index",}])
 
-  (is (thrown? Exception (pg/migrate-up context "with_error")))
+  (is (thrown? Exception (pg/migrate-up context "20250216220942_with_error")))
 
   (pg/migrate-down context)
 
@@ -74,7 +74,7 @@
 
   (matcho/match
       (pg/execute! context {:sql "select * from _migrations"})
-    [{:id "init", :file "20250216211605_init",}
+    [{:id "20250216211605_init", :file "20250216211605_init",}
      nil?])
 
   (pg/migrate-down context)


### PR DESCRIPTION
CAUTION: this PR breaks backwards compatibility of functions `migrate-up` and `migrate-down`

We decided to change how migrations are identified because it was impossible to apply migrations with the same name, e.g. 20250216211605_init.sql and 20250603000000_init.sql (both of these migrations would have the same id "init").

Even if you applied a migration called "foobar" long ago, and since then removed the file, there's still a record with id "foobar" in _migrations table that'll prevent you from applying a new migration that happens to be named "foobar".

Now migrations are identified by filename, which is more unique because it contains a timestamp.